### PR TITLE
Add AGPL notice to Rust source files

### DIFF
--- a/src/bin/bootstrap_tool.rs
+++ b/src/bin/bootstrap_tool.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 #![forbid(unsafe_code)]
 
 use std::collections::HashSet;

--- a/src/bin/chhaya.rs
+++ b/src/bin/chhaya.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 #![forbid(unsafe_code)]
 
 use std::fs;

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 use crate::pin::PinPolicy;
 use crate::quorum::QuorumDescriptor;
 use crate::Kem;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 use aes_gcm::{
     aead::{Aead, KeyInit, Payload},
     Aes256Gcm, Nonce,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,2 +1,5 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 /// Networking rate limiter utilities shared across the crate.
 pub mod ratelimit;

--- a/src/net/ratelimit.rs
+++ b/src/net/ratelimit.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 #![allow(clippy::module_name_repetitions)]
 
 use std::collections::HashMap;

--- a/src/p2p/bootstrap.rs
+++ b/src/p2p/bootstrap.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 #![forbid(unsafe_code)]
 
 use std::collections::HashSet;

--- a/src/p2p/exchange.rs
+++ b/src/p2p/exchange.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 #![allow(clippy::module_name_repetitions)]
 
 use std::io;

--- a/src/p2p/ipfs.rs
+++ b/src/p2p/ipfs.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 #![forbid(unsafe_code)]
 
 use std::fmt;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 #![forbid(unsafe_code)]
 
 /// Bootstrap list verification and quorum helpers.

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 #![forbid(unsafe_code)]
 
 use libipld::cid::Cid;

--- a/src/quorum.rs
+++ b/src/quorum.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 use blstrs::{pairing, G1Projective, G2Affine, G2Projective, Scalar};
 use ff::Field;
 use group::{prime::PrimeCurveAffine, Curve, Group};

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 #![forbid(unsafe_code)]
 
 //! Garlic routing primitives for Chhaya.

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 use hex;
 use qrcode::QrCode;
 

--- a/src/security/audit.rs
+++ b/src/security/audit.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 use zeroize::Zeroizing;
 
 #[cfg(test)]

--- a/src/security/device.rs
+++ b/src/security/device.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 use std::collections::{HashMap, VecDeque};
 use std::marker::PhantomData;
 use std::time::{Duration, Instant};

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 /// Secret-handling helpers used during audits and key management.
 pub mod audit;
 /// Device enrollment, revocation, and compromise containment primitives.

--- a/src/vkd/cache.rs
+++ b/src/vkd/cache.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 #![forbid(unsafe_code)]
 
 use std::collections::{hash_map::Entry, HashMap};

--- a/src/vkd/client.rs
+++ b/src/vkd/client.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 use hex::encode as hex_encode;
 use std::collections::{BTreeMap, HashSet};
 use std::error::Error as StdError;

--- a/src/vkd/gossip.rs
+++ b/src/vkd/gossip.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 #![allow(clippy::module_name_repetitions)]
 
 use std::collections::HashSet;

--- a/src/vkd/mod.rs
+++ b/src/vkd/mod.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 /// Disk-backed verification queue for VKD proofs.
 pub mod cache;
 /// Client-side validation utilities for VKD signed tree heads.

--- a/src/vkd/trust.rs
+++ b/src/vkd/trust.rs
@@ -1,3 +1,6 @@
+// This file is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later.
+// See the LICENSE file in the project root for license details.
+
 #![forbid(unsafe_code)]
 
 use blstrs::{G1Affine, G1Projective, G2Affine, G2Projective};


### PR DESCRIPTION
# Pull Request Template

## Summary
- [ ] Explain the protocol- or security-relevant changes and why they are needed.
This pull request adds license headers to all Rust source files in the project, ensuring each file clearly states that it is part of Chhaya and is licensed under the GNU Affero General Public License v3.0 or later. No functional or behavioral changes are introduced; the updates are solely for legal and documentation purposes.

License and documentation updates:

* Added standardized AGPLv3 license headers to the top of all source files, including but not limited to `src/lib.rs`, `src/directory.rs`, `src/p2p/*`, `src/vkd/*`, `src/security/*`, and others.
- [ ] Note any impacts to decentralization, privacy guarantees, or cryptographic flows.

## Testing & Verification
Check all commands that were executed locally for this change:
- [ ] `cargo fmt --all`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo test --all`
- [ ] Property tests (`cargo test --all -- --ignored` or module-specific)
- [ ] `cargo fuzz run <target>` (if a touched fuzz target exists)
- [ ] `cargo deny check`
- [ ] `cargo audit`

## Security Review
- [ ] Deterministic nonces (HKDF-n12) preserved where applicable.
- [ ] Secrets are zeroized or otherwise cleared on drop.
- [ ] No new panics or `unwrap`/`expect` on untrusted input.
- [ ] No plaintext metadata is introduced on the wire; sealed-sender envelope integrity maintained.
- [ ] Directory updates still require `verify_vkd_proof` success prior to acceptance.

## Additional Notes
Add context that reviewers or operators should know, including protocol diagrams, threat-model implications, or follow-up tasks.
